### PR TITLE
Speed Check for ReachA

### DIFF
--- a/src/ethaniccc/Mockingbird/detections/combat/reach/ReachA.php
+++ b/src/ethaniccc/Mockingbird/detections/combat/reach/ReachA.php
@@ -6,6 +6,7 @@ use ethaniccc\Mockingbird\detections\NopDetection;
 use ethaniccc\Mockingbird\user\User;
 use ethaniccc\Mockingbird\utils\boundingbox\AABB;
 use ethaniccc\Mockingbird\utils\EvictingList;
+use pocketmine\entity\effect\VanillaEffects;
 use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\InventoryTransactionPacket;
 use pocketmine\network\mcpe\protocol\PlayerAuthInputPacket;
@@ -17,11 +18,20 @@ use pocketmine\utils\TextFormat;
  * @package ethaniccc\Mockingbird\detections\combat\reach
  * ReachA uses locations the client has received of the entity and
  * creates bounding boxes from those locations. With those bounding boxes, we get the distance from the user's
- * current eye pos and last eye pos to the bounding boc [@see AABB::distanceFromVector()] and store that in a list, then gets the minimum distance in the list.
+ * current eye pos and last eye pos to the bounding box [@see AABB::distanceFromVector()] and store that in a list, then gets the minimum distance in the list.
  * If the distance exceeds a threshold and the buffer exceeds a level, flag.
  */
+
 class ReachA extends NopDetection{
 	private bool $awaitingMove = false;
+	
+	private const BASE_THRESHOLD = 3.075;
+	private const SPEED_MULTIPLIERS = [
+		0 => 1.0,
+		1 => 1.05,
+		2 => 1.12,
+		3 => 1.20
+	];
 
 	public function __construct(string $name, ?array $settings){
 		parent::__construct($name, $settings);
@@ -43,17 +53,35 @@ class ReachA extends NopDetection{
 			}
 			$distance = $list->minOrElse(-1.0);
 			if($distance !== -1.0){
-				if($distance >= 3.075){
+				$speedLevel = 0;
+				$speedEffect = $user->player->getEffects()->get(VanillaEffects::SPEED());
+				if($speedEffect !== null){
+					$speedLevel = min($speedEffect->getAmplifier() + 1, 3);
+				}
+				
+				$dynamicThreshold = self::BASE_THRESHOLD * (self::SPEED_MULTIPLIERS[$speedLevel] ?? 1.0);
+				
+				if($speedLevel >= 2){
+					$dynamicThreshold += 0.05 * ($speedLevel - 1);
+				}
+				
+				if($distance >= $dynamicThreshold){
 					if(++$this->preVL >= 4){
 						$roundedDist = round($distance, 2);
-						$this->fail($user, 'dist=' . $distance . ' buff=' . $this->preVL, 'dist=' . $roundedDist);
+						$this->fail($user, 
+							'dist=' . $distance . ' buff=' . $this->preVL . ' speed=' . $speedLevel, 
+							'dist=' . $roundedDist . ' speed=' . $speedLevel
+						);
 						$this->preVL = min($this->preVL, 5);
 					}
 				}else{
-					$this->preVL = max($this->preVL - 0.025, 0);
+					$reduction = $speedLevel > 0 ? 0.035 : 0.025;
+					$this->preVL = max($this->preVL - $reduction, 0);
 				}
+				
 				if($this->isDebug($user)){
-					$user->sendMessage($distance > 3.05 ? TextFormat::RED . 'dist=' . $distance . ' buff=' . $this->preVL : 'dist=' . $distance . ' buff=' . $this->preVL);
+					$color = $distance > $dynamicThreshold ? TextFormat::RED : TextFormat::WHITE;
+					$user->sendMessage($color . 'dist=' . round($distance, 3) . ' buff=' . $this->preVL . ' threshold=' . round($dynamicThreshold, 3) . ' speed=' . $speedLevel);
 				}
 			}
 			$this->awaitingMove = false;

--- a/src/ethaniccc/Mockingbird/detections/movement/omnisprint/OmniSprintA.php
+++ b/src/ethaniccc/Mockingbird/detections/movement/omnisprint/OmniSprintA.php
@@ -4,11 +4,13 @@ namespace ethaniccc\Mockingbird\detections\movement\omnisprint;
 
 use ethaniccc\Mockingbird\detections\NopDetection;
 use ethaniccc\Mockingbird\user\User;
+use pocketmine\entity\effect\VanillaEffects;
 use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\PlayerAuthInputPacket;
 
 class OmniSprintA extends NopDetection{
 	private bool $allowed = false;
+	private int $graceBuffer = 0;
 
 	public function __construct(string $name, ?array $settings){
 		parent::__construct($name, $settings);
@@ -16,17 +18,67 @@ class OmniSprintA extends NopDetection{
 
 	public function handleReceive(DataPacket $packet, User $user) : void{
 		if($packet instanceof PlayerAuthInputPacket){
-			// Microjang is high and allows players to sprint backwards in this scenario.
+			$speedLevel = 0;
+			$speedEffect = $user->player->getEffects()->get(VanillaEffects::SPEED());
+			if($speedEffect !== null){
+				$speedLevel = min($speedEffect->getAmplifier() + 1, 3);
+			}
+			
 			if($user->player->isSprinting() && in_array('W', $user->moveData->pressedKeys)){
 				$this->allowed = true;
+				$this->graceBuffer = 0;
 			}elseif(!$user->player->isSprinting()){
 				$this->allowed = false;
+				$this->graceBuffer = 0;
 			}
+			
+			if($speedLevel >= 2 && $user->player->isSprinting() && !$this->allowed){
+				$keys = $user->moveData->pressedKeys;
+				$hasW = in_array('W', $keys);
+				$hasLateral = in_array('A', $keys) || in_array('D', $keys);
+				$hasS = in_array('S', $keys);
+				
+				if($hasW && $hasLateral && !$hasS){
+					$this->graceBuffer = max(0, $this->graceBuffer - 1);
+					if($this->graceBuffer <= 0){
+						$this->allowed = true;
+					}
+				}
+				elseif($hasS || (!$hasW && count($keys) > 0)){
+					$this->graceBuffer = min($this->graceBuffer + 2, 10);
+				}
+			}
+			
+			$requiredBuffer = match($speedLevel) {
+				0, 1 => 0,
+				2 => 3,
+				3 => 5,
+				default => 0
+			};
+			
 			if(!$this->allowed && count($user->moveData->pressedKeys) > 0 && $user->player->isSprinting()){
-				$this->fail($user, 'keys=' . implode(',', $user->moveData->pressedKeys));
+				if($speedLevel < 2 || $this->graceBuffer >= $requiredBuffer){
+					$isSuspicious = true;
+					if($speedLevel >= 2){
+						$keys = $user->moveData->pressedKeys;
+						$isSuspicious = in_array('S', $keys) || !in_array('W', $keys);
+					}
+					
+					if($isSuspicious){
+						$this->fail($user, 
+							'keys=' . implode(',', $user->moveData->pressedKeys) . ' speed=' . $speedLevel . ' buffer=' . $this->graceBuffer,
+							'keys=' . implode(',', $user->moveData->pressedKeys) . ' speed=' . $speedLevel
+						);
+					}
+				}
 			}
+			
 			if($this->isDebug($user)){
-				$user->sendMessage('sprint=' . ($user->player->isSprinting() ? 'true' : 'false') . ' keys=' . implode(',', $user->moveData->pressedKeys));
+				$user->sendMessage('sprint=' . ($user->player->isSprinting() ? 'true' : 'false') . 
+					' keys=' . implode(',', $user->moveData->pressedKeys) . 
+					' speed=' . $speedLevel . 
+					' buffer=' . $this->graceBuffer . 
+					' allowed=' . ($this->allowed ? 'true' : 'false'));
 			}
 		}
 	}


### PR DESCRIPTION
# ReachA

Improves the ReachA check by dynamically adjusting the reach threshold based on the player Speed effect level.

#     Changes
>       Added detection of the player's Speed effect and its level.
>       The reach threshold is now multiplied by a factor depending on the Speed level.
>       Slightly increased the threshold for higher Speed levels to further reduce false positives.
>       Updated debug messages to include Speed level and dynamic threshold.
 
#    Why?
Previously, players with Speed effects could be falsely flagged by the reach check.
With this change, the check is more accurate and fair for players with Speed.

# OmniSprintA 

OmniSprintA check by considering the player Speed effect level when determining suspicious sprinting behavior.
The buffer and allowed states are now dynamically adjusted based on the Speed effect, which helps to reduce false positives for players with Speed II or higher.

#   Changes
>       Added detection of the player's Speed effect and its level.
>       Adjusted grace buffer and required buffer based on Speed level.
>       Improved logic to better handle legitimate sprinting with Speed II+.
>       Updated debug messages to include Speed level, buffer, and allowed state.

#    Why?
          Previously, players with Speed II or higher could be incorrectly flagged for omni-sprinting.
          With this change, the check is more accurate and fair for players using higher Speed effects.